### PR TITLE
Replacing to new URL format supported by tinfoil.

### DIFF
--- a/index.js
+++ b/index.js
@@ -379,7 +379,7 @@ async function addToFile(folder, driveId = null) {
 				}
 
 				const jsonFile = {
-					url: `https://docs.google.com/uc?export=download&id=${file.id}#${encodeURIComponent(gamename).replace('+', '%20').replace(' ', '%20')}`,
+					url: `gdrive:/${file.id}#${encodeURIComponent(gamename).replace('+', '%20').replace(' ', '%20')}`,
 					size: Number(file.size)
 				}
 


### PR DESCRIPTION
Old URL doesn't work anymore and blawar recommended to use only the new format.